### PR TITLE
Fix __repr__ for And and Or matchers

### DIFF
--- a/callee/base.py
+++ b/callee/base.py
@@ -302,8 +302,8 @@ class And(BaseMatcher):
     def match(self, value):
         return all(matcher.match(value) for matcher in self._matchers)
 
-    def __repr__(self, value):
-        return "<%s>" % " and ".join(map(repr, self.matchers))
+    def __repr__(self):
+        return "<%s>" % " and ".join(map(repr, self._matchers))
 
 
 class Or(BaseMatcher):
@@ -320,5 +320,5 @@ class Or(BaseMatcher):
     def match(self, value):
         return any(matcher.match(value) for matcher in self._matchers)
 
-    def __repr__(self, value):
-        return "<%s>" % " or ".join(map(repr, self.matchers))
+    def __repr__(self):
+        return "<%s>" % " or ".join(map(repr, self._matchers))


### PR DESCRIPTION
I cannot use the `And` matcher in my tests, since the test crashes if `mock` decides to print out the matcher using `__repr__`. It looks like the `__repr__` functions for `And` and `Or` incorrectly have the `value` argument?

I assume these haven't actually been used previously, since these two methods also reference `self.matchers` instead of the correct `self._matchers` (which would have been caught earlier if they were actually called).

Let me know if the `value` arg is intended behaviour. It seems that the `value` arg is not used though, and it's highly unusual for `__repr__()` to have more args than just `self`.